### PR TITLE
LPS 195363

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -418,7 +418,9 @@ public class ContentPageLayoutEditorDisplayContext
 					portletURL.setParameter(
 						"redirect", themeDisplay.getURLCurrent());
 
-					return portletURL.toString();
+					return HttpComponentsUtil.addParameter(
+						portletURL.toString(), "p_l_back_url_title",
+						"aqui-va-el-back-url-title-que-toca");
 				});
 		}
 

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -99,6 +99,16 @@ public class EditSegmentsEntryDisplayContext {
 		return _backURL;
 	}
 
+	public String getBackURLTitle() {
+		Map<String, String> backUrl = _getQueryMap(_backURL);
+
+		if (backUrl.containsKey("p_l_back_url_title")) {
+			return backUrl.get("p_l_back_url_title");
+		}
+
+		return LanguageUtil.get(_httpServletRequest, "segments");
+	}
+
 	public Map<String, Object> getData() throws Exception {
 		if (_data != null) {
 			return _data;
@@ -399,6 +409,21 @@ public class EditSegmentsEntryDisplayContext {
 		).put(
 			"showInEditMode", _isShowInEditMode()
 		).build();
+	}
+
+	private Map<String, String> _getQueryMap(String query) {
+		String[] params = query.split(StringPool.AMPERSAND);
+
+		Map<String, String> map = new HashMap<>();
+
+		for (String param : params) {
+			String name = param.split(StringPool.EQUAL)[0];
+			String value = param.split(StringPool.EQUAL)[1];
+
+			map.put(name, value);
+		}
+
+		return map;
 	}
 
 	private String _getSegmentsCompanyConfigurationURL() {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -15,6 +15,7 @@ String backURL = editSegmentsEntryDisplayContext.getBackURL();
 if (Validator.isNotNull(backURL)) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(backURL);
+	portletDisplay.setURLBackTitle(LanguageUtil.get(request, "segments"));
 }
 
 renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -15,7 +15,7 @@ String backURL = editSegmentsEntryDisplayContext.getBackURL();
 if (Validator.isNotNull(backURL)) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(backURL);
-	portletDisplay.setURLBackTitle(LanguageUtil.get(request, "segments"));
+	portletDisplay.setURLBackTitle(editSegmentsEntryDisplayContext.getBackURLTitle());
 }
 
 renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -100,6 +100,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 
 		try {
 			String backURL = ParamUtil.getString(resourceRequest, "backURL");
+			String backURLTitle = ParamUtil.getString(
+				resourceRequest, "backUrlTitle");
 			String redirect = ParamUtil.getString(resourceRequest, "redirect");
 
 			long plid = ParamUtil.getLong(resourceRequest, "plid");
@@ -117,8 +119,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 				JSONUtil.put(
 					"context",
 					_getContextJSONObject(
-						backURL, layout, httpServletRequest, redirect,
-						segmentsExperienceId)
+						backURL, backURLTitle, layout, httpServletRequest,
+						redirect, segmentsExperienceId)
 				).put(
 					"props",
 					_getPropsJSONObject(
@@ -203,7 +205,7 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 	}
 
 	private JSONObject _getContextJSONObject(
-			String backURL, Layout layout,
+			String backURL, String backURLTitle, Layout layout,
 			HttpServletRequest httpServletRequest, String redirect,
 			long segmentsExperienceId)
 		throws Exception {
@@ -268,7 +270,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 			).put(
 				"editSegmentsVariantLayoutURL",
 				_getEditSegmentsVariantLayoutURL(
-					backURL, layout, redirect, segmentsExperienceId)
+					backURL, backURLTitle, layout, redirect,
+					segmentsExperienceId)
 			).put(
 				"editSegmentsVariantURL",
 				_getSegmentsExperimentActionURL(
@@ -296,7 +299,7 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 	}
 
 	private String _getEditSegmentsVariantLayoutURL(
-		String backURL, Layout layout, String redirect,
+		String backURL, String backURLTitle, Layout layout, String redirect,
 		long segmentsExperienceId) {
 
 		Layout draftLayout = _layoutLocalService.fetchDraftLayout(
@@ -307,19 +310,13 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 		}
 
 		if (segmentsExperienceId != -1) {
-			backURL = HttpComponentsUtil.setParameter(
+			backURL = HttpComponentsUtil.addParameter(
 				backURL, "segmentsExperienceId", segmentsExperienceId);
 		}
 
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "p_l_back_url", backURL);
-
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "p_l_mode", Constants.EDIT);
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "redirect", redirect);
-
-		return redirect;
+		return HttpComponentsUtil.addParameters(
+			redirect, "p_l_back_url", backURL, "p_l_back_url_title",
+			backURLTitle, "p_l_mode", Constants.EDIT, "redirect", redirect);
 	}
 
 	private long _getLiveGroupId(long groupId) throws Exception {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -324,6 +324,13 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 		).setBackURL(
 			layoutURL
 		).setParameter(
+			"backUrlTitle",
+			() -> {
+				Layout layout = themeDisplay.getLayout();
+
+				return layout.getName(_portal.getLocale(httpServletRequest));
+			}
+		).setParameter(
 			"plid", themeDisplay.getPlid()
 		).setParameter(
 			"segmentsExperienceId",


### PR DESCRIPTION
- LPS-195363 Set backURLTitle with the name of the with the name of the page
- LPS-195363 Use backURLTitle for when a Variant is being edited
- LPS-195363 Use portletDisplay setBackURLTitle method to indicate the back button takes to the Segments page
- LPS-195363 Check if the portletURL contains the p_l_back_url_title to know from where it is used
- LPS-195363 WIP
